### PR TITLE
Makefile.PL - use meta-spec 2, fix prereqs, compatibility with old EUMM

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,33 +3,47 @@ use strict;
 use warnings;
 use ExtUtils::MakeMaker;
 
-WriteMakefile(
+my %WriteMakefile_args = (
     'NAME'               => 'Digest',
     'AUTHOR'             => 'Gisle Aas <gisle@activestate.com>',
     'VERSION_FROM'       => 'lib/Digest.pm',
     'ABSTRACT_FROM'      => 'lib/Digest.pm',
     'LICENSE'            => 'perl',
     'MIN_PERL_VERSION'   => '5.006',
-    'CONFIGURE_REQUIRES' => {
-        'ExtUtils::MakeMaker' => '0',
-    },
     'PREREQ_PM' => {
         'MIME::Base64' => 0,
-        'Test::More'   => '0.47'
     },
     'TEST_REQUIRES' => {
-        'Test::More' => '0',
+        'Test::More' => '0.47',
     },
     'INSTALLDIRS' => ( ( $] >= '5.009005' && $] < '5.012' ) ? 'perl' : 'site' ),
     'dist'        => { 'COMPRESS' => 'gzip -9f', 'SUFFIX' => 'gz', },
     'clean'       => { 'FILES' => 'Digest-*' },
 
     'META_MERGE' => {
+        'meta-spec' => { 'version' => 2 },
+        'dynamic_config' => 0,
         'resources' => {
-            'license'    => 'http://dev.perl.org/licenses/',
-            'bugtracker' => 'https://github.com/Dual-Life/digest/issues',
-            'repository' => 'https://github.com/dual-Life/digest/',
-
+            'license'    => [ 'http://dev.perl.org/licenses/' ],
+            'bugtracker' => { 'web' => 'https://github.com/Dual-Life/digest/issues' },
+            'repository' => {
+                'type' => 'git',
+                'url' => 'https://github.com/Dual-Life/digest.git',
+                'web' => 'https://github.com/Dual-Life/digest',
+            },
         }
     },
 );
+
+delete $WriteMakefile_args{LICENSE}
+  unless eval { ExtUtils::MakeMaker->VERSION('6.31') };
+delete $WriteMakefile_args{META_MERGE}
+  unless eval { ExtUtils::MakeMaker->VERSION('6.46') };
+delete $WriteMakefile_args{MIN_PERL_VERSION}
+  unless eval { ExtUtils::MakeMaker->VERSION('6.48') };
+unless (eval { ExtUtils::MakeMaker->VERSION('6.64') }) {
+  my $test_requires = delete $WriteMakefile_args{TEST_REQUIRES};
+  $WriteMakefile_args{PREREQ_PM}{$_} = $test_requires->{$_} for keys %$test_requires;
+}
+
+WriteMakefile(%WriteMakefile_args);


### PR DESCRIPTION
- meta-spec 2 resources format
- dependencies are static, set dynamic_config 0
- EUMM will set configure_requires on itself
- Test::More only used in tests
- boilerplate to clean out unsupported keys if installed with old EUMM