### PR TITLE
base.t, file.t: unlink temporary files created during testing

### DIFF
--- a/t/base.t
+++ b/t/base.t
@@ -60,7 +60,7 @@ $ctx->add("foo");
 is( $ctx->b64digest, $EBCDIC ? "hvDw8PM" : "ZjAwMDM" );
 
 {
-    my ( $fh, $tempfile ) = tempfile();
+    my ( $fh, $tempfile ) = tempfile( UNLINK => 1 );
     binmode($fh);
     print $fh "abc" x 100, "\n";
     close($fh) || die;

--- a/t/file.t
+++ b/t/file.t
@@ -35,7 +35,7 @@ use File::Temp 'tempfile';
 use Digest::file qw(digest_file digest_file_hex digest_file_base64);
 
 {
-    my ( $fh, $file ) = tempfile();
+    my ( $fh, $file ) = tempfile( UNLINK => 1 );
     binmode($fh);
     print $fh "foo\0\n";
     close($fh) || die "Can't write '$file': $!";


### PR DESCRIPTION
I run the Perl 5 core distribution's test suite dozens of times each week.  If a test file within the core distribution's test suite creates a temporary file but fails to remove it before the test program completes, then I accumulate a large number of such tempfiles on my machine's `/tmp`.

The Digest distribution on CPAN ships with the core.  Two of its test files create tempfiles but fail to remove them.  Consequently, I accumulate a large number of files with identical content.  Examples:
```
$ ls -ltr /tmp | tail -n 3
-rw-------  1 jkeenan  wheel         5 Aug 24 02:09 9Oq34QLwyH
-rw-------  1 jkeenan  wheel       301 Aug 24 02:09 lCcOQJNXNf
-rw-r--r--  1 root     wheel         0 Aug 24 02:14 zpool-io.tmp

$ head 9Oq34QLwyH lCcOQJNXNf 
==> 9Oq34QLwyH <==
foo

==> lCcOQJNXNf <==
abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc

$ find . -type f -size 301c 2>/dev/null | wc -l
     113
$ find . -type f -size 5c 2>/dev/null | wc -l
     106
```
This pull request unlinks the temporary files once they're no longer needed.  Please review and issue a new CPAN release so that we can synch this into core.

Thank you very much.
Jim Keenan

